### PR TITLE
Hard-coded prototype for grow builds in managed-vms.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM gcr.io/google_appengine/python-compat
+FROM grow/baseimage-managed-vms:0.0.53
+MAINTAINER Grow SDK Authors <hello@grow.io>
 
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends git python python-pip wget
-
-# RUN pip install -U pip
-RUN pip install -r requirements.txt
+ADD requirements.txt /app/requirements.txt
+RUN pip install -r /app/requirements.txt
 
 ADD . /app
+WORKDIR /app

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,8 @@
 from . import services
+from . import utils
 from protorpc.wsgi import service
 import webapp2
+import subprocess
 
 MESSAGES = '/tmp/messages.txt'
 
@@ -21,9 +23,22 @@ class MessagesHandler(webapp2.RequestHandler):
         self.response.out.write(msg)
 
 
+class TriggerHandler(webapp2.RequestHandler):
+  def get(self):
+    repo = utils.clone_repo('https://github.com/grow/growsdk.org.git', 'master')
+    try:
+      cmd = ['grow', 'build', repo.working_dir]
+      output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+      self.response.out.write('<pre>%s</pre>' % e.output)
+      self.response.set_status(500)
+    else:
+      self.response.out.write('<pre>%s</pre>' % output)
+
 test_app = webapp2.WSGIApplication([
     ('/', HelloHandler),
-    ('/messages', MessagesHandler)
+    ('/messages', MessagesHandler),
+    ('/trigger', TriggerHandler),
 ], debug=True)
 
 

--- a/scripts/run
+++ b/scripts/run
@@ -2,4 +2,4 @@
 
 boot2docker up
 $(boot2docker shellinit)
-gcloud preview --project googwebreview-dev app run ./app.yaml
+GAE_LOCAL_VM_RUNTIME=0 gcloud preview --project googwebreview-dev app run ./app.yaml


### PR DESCRIPTION
@jeremydw FYI

Grow builds in a Managed VM:

<img width="644" alt="screen shot 2015-08-11 at 4 55 34 pm" src="https://cloud.githubusercontent.com/assets/75300/9214006/933dca2c-404d-11e5-83b7-0ec9ab389855.png">

All the actual magic is contained in the new https://github.com/grow/baseimage-managed-vms — with this you can simply inherit `FROM grow/baseimage-managed-vms:0.0.53` and the resulting image will work with Managed VMs and have grow installed.

NOTE: We'll rip this out later since this should never be used in an actual production env—this probably has a bunch of security vulnerabilities because it injects the process output directly into HTML.

I'll submit this after the Docker Hub repos are set up.
